### PR TITLE
test: add fetchPage mocking tests

### DIFF
--- a/tests/fetcher.test.ts
+++ b/tests/fetcher.test.ts
@@ -1,2 +1,63 @@
-// Fetcherのテストはネットワーク依存のため削除
-// 実際のWebページ取得はインテグレーションテストで実施すべき
+process.env.OPENROUTER_API_KEY = 'dummy';
+process.env.NAV_WAIT_MS = '0';
+process.env.RETRY_COUNT = '0';
+process.env.REQUEST_TIMEOUT_MS = '1000';
+
+import { describe, it, expect, afterAll } from 'vitest';
+import http from 'http';
+import { fetcher } from '../src/fetcher.js';
+
+async function startServer(
+  handler: (req: http.IncomingMessage, res: http.ServerResponse) => void,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise(resolve => {
+    const server = http.createServer(handler);
+    server.listen(0, () => {
+      const addr = server.address();
+      if (addr && typeof addr !== 'string') {
+        resolve({
+          url: `http://127.0.0.1:${addr.port}`,
+          close: () =>
+            new Promise<void>(resolveClose => server.close(() => resolveClose())),
+        });
+      }
+    });
+  });
+}
+
+describe('fetchPage', () => {
+  afterAll(async () => {
+    await fetcher.close();
+  });
+
+  it('returns success for 200 response', async () => {
+    const server = await startServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('<html><head><title>ok</title></head><body>Hello</body></html>');
+    });
+
+    try {
+      const result = await fetcher.fetchPage(server.url);
+      expect(result.success).toBe(true);
+      expect(result.title).toBe('ok');
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('returns error for 404 response', async () => {
+    const server = await startServer((req, res) => {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('not found');
+    });
+
+    try {
+      const result = await fetcher.fetchPage(server.url);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('HTTPエラー: 404');
+    } finally {
+      await server.close();
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary
- mock fetcher requests with a local HTTP server
- assert 200 responses succeed and 404 responses fail
- ensure mock server shuts down even if assertions fail

## Testing
- `env OPENROUTER_API_KEY=dummy NAV_WAIT_MS=0 RETRY_COUNT=0 REQUEST_TIMEOUT_MS=1000 npm run test:run`

------
https://chatgpt.com/codex/tasks/task_e_689724d98dd483228e47a87db0471e48