### PR TITLE
docs: CLIオプションをヘルプ出力に合わせて更新 (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,20 @@
 
 - 新規参加者は [docs/manual/onboarding.md](docs/manual/onboarding.md) を参照してください
 - 詳細な要件と設計は [docs/](docs) 以下にまとめています
+
+## CLI
+
+ヘルプは次のコマンドで表示できます:
+
+```bash
+OPENROUTER_API_KEY=dummy npm run start -- --help
+```
+
+### 主なオプション
+
+- `--companies <path>`: 企業リストCSVファイルのパス（デフォルト: `data/companies.csv`）
+- `--urls <path>`: URLリストCSVファイルのパス（デフォルト: `data/urls.csv`）
+- `--output <path>`: 結果出力先のパス（デフォルト: `output/results_[timestamp].csv`）
+- `--parallel <num>`: 並列処理数（デフォルト: 3）
+
+詳細は [docs/cli-commands.md](docs/cli-commands.md) を参照してください

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -12,19 +12,16 @@
 
 ## コマンド一覧
 
-### 1. extract - 従業員数抽出（デフォルト）
+### 1. start - 従業員数抽出
 
 企業リストとURLリストから従業員数を自動抽出します。
 
 ```bash
 # 基本使用法
-npm run poc extract
+npm run start
 
 # オプション指定
-npm run poc extract -- --companies data/companies.csv --urls data/urls.csv --parallel 5
-
-# 省略形（extractはデフォルトコマンド）
-npm run poc
+npm run start -- --companies data/companies.csv --urls data/urls.csv --parallel 5
 ```
 
 **オプション:**


### PR DESCRIPTION
## Summary
- align CLI help documentation with `npm run start -- --help`
- add CLI section to README with main options

## Testing
- `OPENROUTER_API_KEY=dummy npm run start -- --help`
- `OPENROUTER_API_KEY=dummy npm test` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_6897de8bc20483229a7bd871eab25400